### PR TITLE
fix casing issue for customer create and edit page

### DIFF
--- a/EasyAppointmentManager/Views/Customers/Create.cshtml
+++ b/EasyAppointmentManager/Views/Customers/Create.cshtml
@@ -50,7 +50,7 @@ else
 
                     <span>&emsp;</span>
                     @Html.RadioButtonFor(model => model.Gender, false)
-                    <span>FeMale</span>
+                    <span>Female</span>
 
                 </div>
                 <div class="form-group">

--- a/EasyAppointmentManager/Views/Customers/Edit.cshtml
+++ b/EasyAppointmentManager/Views/Customers/Edit.cshtml
@@ -46,7 +46,7 @@
 
                 <span>&emsp;</span>
                 @Html.RadioButtonFor(model => model.Gender, false)
-                <span>FeMale</span>
+                <span>Female</span>
             </div>
             <div class="form-group">
                 <label asp-for="PhoneNumber" class="control-label"></label>


### PR DESCRIPTION
Closes #85 
Fixed a casing error in Customer create and edit page where Female was displayed as FeMale.